### PR TITLE
Added TMPDIR var to ruby_build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Cookbook `ruby_lwrp` builds various versions of ruby and installs them to `/opt/
 * `node['ruby']['ruby_build']['git_url']` -  Defaults to `"git://github.com/sstephenson/ruby-build.git"`.
 * `node['ruby']['ruby_build']['git_ref']` -  Defaults to `"master"`.
 * `node['ruby']['ruby_build']['install_pkgs']` -  Defaults to `"%w(build-essential bison openssl libreadline6 libreadline6-dev zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev ssl-cert subversion git-core libffi-dev)"`.
+* `node['ruby']['ruby_build']['tmp_dir_path']` - Defaults to '"/tmp"'. It sets TMPDIR for ruby-build.
 
 # Recipes
 

--- a/attributes/ruby_build.rb
+++ b/attributes/ruby_build.rb
@@ -2,3 +2,4 @@ default['ruby']['ruby_build']['install_path'] = '/opt/ruby-build'
 default['ruby']['ruby_build']['git_url'] = 'git://github.com/sstephenson/ruby-build.git'
 default['ruby']['ruby_build']['git_ref'] = 'master'
 default['ruby']['ruby_build']['install_pkgs'] =  %w(build-essential bison openssl libreadline6 libreadline6-dev zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0 libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev ssl-cert subversion git-core libffi-dev)
+default['ruby']['ruby_build']['tmp_dir_path'] = '/tmp'

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -32,6 +32,7 @@ provides :ruby_install
 
 action :install do
   ruby_build_install_path = node['ruby']['ruby_build']['install_path']
+  tmp_dir_path = node['ruby']['ruby_build']['tmp_dir']
 
   if new_resource.build_ruby
 
@@ -41,7 +42,7 @@ action :install do
       Chef::Log.info("Installing ruby #{new_resource.definition}...")
 
       execute "ruby_install-#{new_resource.definition}" do
-        command "#{ruby_build_install_path}/bin/ruby-build #{new_resource.definition} #{new_resource.prefix}/#{new_resource.definition}"
+        command "TMPDIR=#{tmp_dir_path} #{ruby_build_install_path}/bin/ruby-build #{new_resource.definition} #{new_resource.prefix}/#{new_resource.definition}"
       end.run_action(:run)
 
       new_resource.updated_by_last_action(true)


### PR DESCRIPTION
Ruby-build has default TMPDIR equal to `/tmp`. But in some systems, for example Rackspace, `/tmp` has `noexec` attribute and ruby-build is failing. 
For example, https://github.com/sstephenson/ruby-build/issues/703

This PR adds possibility to configure TMPDIR through `tmp_dir_path` attribute.
